### PR TITLE
Add lookup engines for CDU in Australia

### DIFF
--- a/engines_json/au.nt.charles_darwin_university_doi_search.json
+++ b/engines_json/au.nt.charles_darwin_university_doi_search.json
@@ -1,0 +1,14 @@
+{
+  "title": "Charles Darwin University - DOI Search",
+  "name": "au.nt.charles_darwin_university_doi_search",
+  "alias": "CDU-DOI",
+  "icon": "http://cdu.edu.au/favicon.ico",
+  "_urlTemplate": "https://cdu-edu-primo.hosted.exlibrisgroup.com/primo-explore/search?institution=61CDU_INT&vid=61CDU&query=any,contains,{z:DOI}",
+  "description": "CDU search by DOI",
+  "hidden": false,
+  "_urlParams": [],
+  "_urlNamespaces": {
+    "z": "http://www.zotero.org/namespaces/openSearch#"
+  },
+  "_iconSourceURI": "http://cdu.edu.au/favicon.ico"
+}

--- a/engines_json/au.nt.charles_darwin_university_title_search.json
+++ b/engines_json/au.nt.charles_darwin_university_title_search.json
@@ -1,0 +1,14 @@
+{
+  "title": "Charles Darwin University - Title Search",
+  "name": "au.nt.charles_darwin_university_title_search",
+  "alias": "CDU-DOI",
+  "icon": "http://cdu.edu.au/favicon.ico",
+  "_urlTemplate": "https://cdu-edu-primo.hosted.exlibrisgroup.com/primo-explore/search?institution=61CDU_INT&vid=61CDU&query=any,contains,{z:title}",
+  "description": "CDU search by DOI",
+  "hidden": false,
+  "_urlParams": [],
+  "_urlNamespaces": {
+    "z": "http://www.zotero.org/namespaces/openSearch#"
+  },
+  "_iconSourceURI": "http://cdu.edu.au/favicon.ico"
+}


### PR DESCRIPTION
Two lookup engines for Charles Darwin University in Australia.
Tested in Zotero 5.0.33