### PR TITLE
Add lookup engines for Bordeaux universities'libraries in France

### DIFF
--- a/engines_json/fr.naq.babord_plus_bordeaux_inp.json
+++ b/engines_json/fr.naq.babord_plus_bordeaux_inp.json
@@ -1,0 +1,14 @@
+{
+    "title": "Babord + - Bordeaux INP",
+    "name": "fr.naq.babord_plus_bordeaux_inp",
+    "country": "FR",
+    "alias": "B+INP",
+    "icon":  "https://babordplus.hosted.exlibrisgroup.com/primo-explore/custom/33PUDB_INP_VU1/img/favicon.ico",
+    "linktemplate": "https://babordplus.hosted.exlibrisgroup.com/primo-explore/search?query=any,contains,{z:title}+{rft:aufirst?}+{rft:aulast?}+{z:ISBN?}+{rft:jtitle?}+{z:ISSN?}+{z:DOI?}&tab=default_tab&search_scope=catalog_pci&vid=33PUDB_INP_VU1&offset=0",
+    "description": "Recherche dans le catalogue des bibliothèques universitaires de Bordeaux via la vue dédiée aux membres de Bordeaux Sciences Agro.",
+    "hidden": false,
+    "_urlParams": [],
+    "_urlNamespaces": {
+      "z": "http://www.zotero.org/namespaces/openSearch#"
+    }
+  }

--- a/engines_json/fr.naq.babord_plus_bordeaux_sciences_agro.json
+++ b/engines_json/fr.naq.babord_plus_bordeaux_sciences_agro.json
@@ -1,0 +1,14 @@
+{
+    "title": "Babord + - Bordeaux Sciences Agro",
+    "name": "fr.naq.babord_plus_bordeaux_sciences_agro",
+    "country": "FR",
+    "alias": "B+BXSA",
+    "icon":  "https://babordplus.hosted.exlibrisgroup.com/primo-explore/custom/33PUDB_BXSA_VU1/img/favicon.ico",
+    "linktemplate": "https://babordplus.hosted.exlibrisgroup.com/primo-explore/search?query=any,contains,{z:title}+{rft:aufirst?}+{rft:aulast?}+{z:ISBN?}+{rft:jtitle?}+{z:ISSN?}+{z:DOI?}&tab=default_tab&search_scope=catalog_pci&vid=33PUDB_BXSA_VU1&offset=0",
+    "description": "Recherche dans le catalogue des bibliothèques universitaires de Bordeaux via la vue dédiée aux membres de Bordeaux Sciences Agro.",
+    "hidden": false,
+    "_urlParams": [],
+    "_urlNamespaces": {
+      "z": "http://www.zotero.org/namespaces/openSearch#"
+    }
+  }

--- a/engines_json/fr.naq.babord_plus_sciences_po_bordeaux.json
+++ b/engines_json/fr.naq.babord_plus_sciences_po_bordeaux.json
@@ -1,0 +1,14 @@
+{
+    "title": "Babord + - Sciences Po Bordeaux",
+    "name": "fr.naq.babord_plus_sciences_po_bordeaux",
+    "country": "FR",
+    "alias": "B+IEP",
+    "icon":  "https://babordplus.hosted.exlibrisgroup.com/primo-explore/custom/33PUDB_IEP_VU1/img/favicon.ico",
+    "linktemplate": "https://babordplus.hosted.exlibrisgroup.com/primo-explore/search?query=any,contains,{z:title}+{rft:aufirst?}+{rft:aulast?}+{z:ISBN?}+{rft:jtitle?}+{z:ISSN?}+{z:DOI?}&tab=default_tab&search_scope=catalog_pci&vid=33PUDB_IEP_VU1&offset=0",
+    "description": "Recherche dans le catalogue des bibliothèques universitaires de Bordeaux via la vue dédiée aux membres de Sciences Po Bordeaux.",
+    "hidden": false,
+    "_urlParams": [],
+    "_urlNamespaces": {
+      "z": "http://www.zotero.org/namespaces/openSearch#"
+    }
+  }

--- a/engines_json/fr.naq.babord_plus_university_bordeaux_montaigne.json
+++ b/engines_json/fr.naq.babord_plus_university_bordeaux_montaigne.json
@@ -1,0 +1,14 @@
+{
+    "title": "Babord + - Université Bordeaux Montaigne",
+    "name": "fr.naq.babord_plus_university_bordeaux_montaigne",
+    "country": "FR",
+    "alias": "B+UBM",
+    "icon":  "https://babordplus.hosted.exlibrisgroup.com/primo-explore/custom/33PUDB_UBM_VU1/img/favicon.ico",
+    "linktemplate": "https://babordplus.hosted.exlibrisgroup.com/primo-explore/search?query=any,contains,{z:title}+{rft:aufirst?}+{rft:aulast?}+{z:ISBN?}+{rft:jtitle?}+{z:ISSN?}+{z:DOI?}&tab=default_tab&search_scope=catalog_pci&vid=33PUDB_UBM_VU1&offset=0",
+    "description": "Recherche dans le catalogue des bibliothèques universitaires de Bordeaux via la vue dédiée aux membres de l'Université Bordeaux Montaigne.",
+    "hidden": false,
+    "_urlParams": [],
+    "_urlNamespaces": {
+      "z": "http://www.zotero.org/namespaces/openSearch#"
+    }
+  }

--- a/engines_json/fr.naq.babord_plus_university_of_bordeaux.json
+++ b/engines_json/fr.naq.babord_plus_university_of_bordeaux.json
@@ -1,0 +1,14 @@
+{
+    "title": "Babord + - Université de Bordeaux",
+    "name": "fr.naq.babord_plus_university_of_bordeaux",
+    "country": "FR",
+    "alias": "B+UBX",
+    "icon":  "https://babordplus.hosted.exlibrisgroup.com/primo-explore/custom/33PUDB_UB_VU1/img/favicon.ico",
+    "linktemplate": "https://babordplus.hosted.exlibrisgroup.com/primo-explore/search?query=any,contains,{z:title}+{rft:aufirst?}+{rft:aulast?}+{z:ISBN?}+{rft:jtitle?}+{z:ISSN?}+{z:DOI?}&tab=default_tab&search_scope=catalog_pci&vid=33PUDB_UB_VU1&offset=0",
+    "description": "Recheche dans le catalogue des bibliothèques universitaires de Bordeaux via la vue dédiée aux membres de l'Université de Bordeaux.",
+    "hidden": false,
+    "_urlParams": [],
+    "_urlNamespaces": {
+      "z": "http://www.zotero.org/namespaces/openSearch#"
+    }
+  }


### PR DESCRIPTION
Hi,
Can you add these five lookup engines for Bordeaux universities'libraries in France.
One search engine  by institution's catalog view.
Best regards,