### PR TITLE
Create swisscovery

### DIFF
--- a/engines_json/swisscovery
+++ b/engines_json/swisscovery
@@ -1,0 +1,6 @@
+{
+  "title": "swisscovery",
+  "name": "swisscovery",
+  "icon": "https://swisscovery.slsp.ch/discovery/custom/41SLSP_NETWORK-VU1_UNION/img/library-logo.png",
+  "linktemplate": "https://swisscovery.slsp.ch/discovery/search?tab=41SLSP_NETWORK&vid=41SLSP_NETWORK:VU1_UNION&query=any,contains,{z:title}&search_scope=DN_and_CI&lang=fr&offset=0"
+}


### PR DESCRIPTION
engine for the swisscovery platform used by almost all the Swiss academic libraries as of December 7, 2020